### PR TITLE
Adds environment file to be used with binder

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,19 @@
+name: smode_retrival
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - netcdf4==1.5.7
+  - pandas==1.3.2
+  - xarray==0.19.0
+  - matplotlib
+  - libnetcdf==4.6.1
+  - scipy==1.7.1
+  - bokeh==2.3.3
+  - datashader==0.13.0
+  - holoviews==1.14.6
+  - hvplot==0.7.3 
+  - cartopy==0.20.0
+  - jupyterlab==3.1.12
+  - ipykernel==6.2.0
+  - siphon

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: smode_retrival
+name: smode_retrieval
 channels:
   - defaults
   - conda-forge


### PR DESCRIPTION
I plan to add a Binder badge on the README so folks can run notebooks without a local python installation. This adds an environment file with all dependencies needed to run the GetNAVOGliderData.ipynb notebook plus some extra for interactive visualization.